### PR TITLE
set OPTFLAGS=""

### DIFF
--- a/Dockerfile14.postgres
+++ b/Dockerfile14.postgres
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get install -y \
     postgresql-server-dev-14 \
     && git clone --branch v0.8.0 https://github.com/pgvector/pgvector.git \
     && cd pgvector \
-    && make \
+    && make OPTFLAGS="" \
     && make install \
     && cd .. \
     && rm -rf pgvector \

--- a/Dockerfile15.postgres
+++ b/Dockerfile15.postgres
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get install -y \
     postgresql-server-dev-15 \
     && git clone --branch v0.8.0 https://github.com/pgvector/pgvector.git \
     && cd pgvector \
-    && make \
+    && make OPTFLAGS="" \
     && make install \
     && cd .. \
     && rm -rf pgvector \

--- a/Dockerfile16.postgres
+++ b/Dockerfile16.postgres
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get install -y \
     postgresql-server-dev-16 \
     && git clone --branch v0.8.0 https://github.com/pgvector/pgvector.git \
     && cd pgvector \
-    && make \
+    && make OPTFLAGS="" \
     && make install \
     && cd .. \
     && rm -rf pgvector \


### PR DESCRIPTION
## Summary

Okay... this is in the weeds...

I was attempting to use the pgvector extension functionality on local, and it was crashing my db!

After confusion and digging, I found the following in the db logs:

```
postgres-1  |           0.8756564259529114,
postgres-1  |           1.0723049640655518,
postgres-1  |           0.28651148080825806,
postgres-1  |           -0.02203105017542839,
postgres-1  |           0.426105260848999]'::vector) asc
postgres-1  |   
postgres-1  | 2025-09-24 21:06:08.849 UTC [1] LOG:  server process (PID 66552) was terminated by signal 4: Illegal instruction
postgres-1  | 2025-09-24 21:06:08.849 UTC [1] DETAIL:  Failed process was running: select
postgres-1  |           "canonical_job_family"."id",
postgres-1  |           "canonical_job_family"."_auto_created_at",
postgres-1  |           "canonical_job_family"."_auto_updated_at",
postgres-1  |           "canonical_job_family"."name",
postgres-1  |           "canonical_job_family"."slug",
postgres-1  |           "canonical_job_family"."parent_job_family_id",
postgres-1  |           "canonical_job_family"."description",
postgres-1  |           "canonical_job_family"."ai_generated_responsibilities",
postgres-1  |           "canonical_job_family"."profile_type",
postgres-1  |           "canonical_job_family"."code",
postgres-1  |           "canonical_job_family"."embedding"
postgres-1  |   from
postgres-1  |           "canonical_job_family"
postgres-1  |   order by
postgres-1  |           ("canonical_job_family"."embedding" <=> '[0.10946442931890488,
postgres-1  |           0.02911740355193615,
postgres-1  |           -0.5138103365898132,
postgres-1  |           -0.809971034526825,
postgres-1  |           -0.3417081832885742,
postgres-1  |           0.07127183675765991,
```

Note:  server process (PID 66552) was terminated by signal 4: Illegal , which led to 

https://github.com/timescale/timescaledb-docker/pull/318

and finding this note:

https://github.com/pgvector/pgvector?tab=readme-ov-file#portability

<img width="970" height="317" alt="image" src="https://github.com/user-attachments/assets/137f8f99-2901-436b-ac3e-196e8ba8cf9a" />


