### PR TITLE
No logging, add 18, remove 16

### DIFF
--- a/.github/workflows/_docker.yml
+++ b/.github/workflows/_docker.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   builder:
     name: builder image
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: 'Checkout GitHub Action'
         uses: actions/checkout@main

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
     name: docker
     strategy:
       matrix:
-        version: [16, 17]
+        version: [17, 18]
     uses: ./.github/workflows/_docker.yml
     with:
       version: "${{ matrix.version }}"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -9,7 +9,7 @@ jobs:
     name: docker
     strategy:
       matrix:
-        version: [16, 17]
+        version: [17, 18]
     uses: ./.github/workflows/_docker.yml
     with:
       version: "${{ matrix.version }}"

--- a/Dockerfile17.postgres
+++ b/Dockerfile17.postgres
@@ -19,4 +19,4 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # log all queries
-CMD ["postgres", "-c", "log_statement=all"]
+CMD ["postgres"]

--- a/Dockerfile18.postgres
+++ b/Dockerfile18.postgres
@@ -1,5 +1,5 @@
 # Same major version as production
-FROM imresamu/postgis:16-3.4.3-bookworm
+FROM imresamu/postgis:18-3.6.0-bookworm
 LABEL org.opencontainers.image.source="https://github.com/trycompa/docker-postgres"
 
 
@@ -7,16 +7,16 @@ LABEL org.opencontainers.image.source="https://github.com/trycompa/docker-postgr
 RUN apt-get update && apt-get install -y \
     build-essential \
     git \
-    postgresql-server-dev-16 \
-    && git clone --branch v0.8.0 https://github.com/pgvector/pgvector.git \
+    postgresql-server-dev-18 \
+    && git clone --branch v0.8.1 https://github.com/pgvector/pgvector.git \
     && cd pgvector \
     && make OPTFLAGS="" \
     && make install \
     && cd .. \
     && rm -rf pgvector \
-    && apt-get remove -y build-essential git postgresql-server-dev-16 \
+    && apt-get remove -y build-essential git postgresql-server-dev-18 \
     && apt-get autoremove -y \
     && rm -rf /var/lib/apt/lists/*
 
 # log all queries
-CMD ["postgres", "-c", "log_statement=all"]
+CMD ["postgres"]

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -5,7 +5,7 @@ ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/" &> /dev/null && pwd )"
 
 cd "$ROOT"
 
-versions=("16" "17")
+versions=("17" "18")
 
 for version in "${versions[@]}"; do
   # linux/amd64


### PR DESCRIPTION
This PR makes a couple of changes:

1. Remove logging by default. I noticed that shutting down this container in our regular build takes almost 50s and it seems like most of it is spent on outputting logging. We can't adjust this in github actions it seems. However we do set this in our regular `docker-compose.yml` so we don't actually need it here. I'm hoping this will reduce the time spent on container shutdown.
2. Add postgres 18, using postgis 3.6.0 and pgvector 0.8.1, which matches the RDS versions
3. Remove postgres 16. We don't use it anymore.