### PR TITLE
Enable `pgvector` and `fuzzystrmatch` extensions by default

### DIFF
--- a/Dockerfile17.postgres
+++ b/Dockerfile17.postgres
@@ -18,5 +18,8 @@ RUN apt-get update && apt-get install -y \
     && apt-get autoremove -y \
     && rm -rf /var/lib/apt/lists/*
 
-# log all queries
+# Entrypoints to enable extensions
+COPY initdb-pgvector.sh /docker-entrypoint-initdb.d/20_pgvector.sh
+COPY initdb-fuzzystrmatch.sh /docker-entrypoint-initdb.d/30_fuzzystrmatch.sh
+
 CMD ["postgres"]

--- a/Dockerfile18.postgres
+++ b/Dockerfile18.postgres
@@ -18,5 +18,8 @@ RUN apt-get update && apt-get install -y \
     && apt-get autoremove -y \
     && rm -rf /var/lib/apt/lists/*
 
-# log all queries
+# Entrypoints to enable extensions
+COPY initdb-pgvector.sh /docker-entrypoint-initdb.d/20_pgvector.sh
+COPY initdb-fuzzystrmatch.sh /docker-entrypoint-initdb.d/30_fuzzystrmatch.sh
+
 CMD ["postgres"]

--- a/initdb-fuzzystrmatch.sh
+++ b/initdb-fuzzystrmatch.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+# Perform all actions as $POSTGRES_USER
+export PGUSER="$POSTGRES_USER"
+
+# Load pgvector into $POSTGRES_DB
+echo "Loading fuzzystrmatch extension into $POSTGRES_DB"
+psql --dbname="$POSTGRES_DB" -c 'CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;'

--- a/initdb-pgvector.sh
+++ b/initdb-pgvector.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+# Perform all actions as $POSTGRES_USER
+export PGUSER="$POSTGRES_USER"
+
+# Load pgvector into $POSTGRES_DB
+echo "Loading pgvector extension into $POSTGRES_DB"
+psql --dbname="$POSTGRES_DB" -c 'CREATE EXTENSION IF NOT EXISTS vector;'


### PR DESCRIPTION
This PR enables the pgvector and fuzzystrmatch extensions by default in the image. Doing this makes it a bit less fiddly on the app side.

Built the image locally, and ran it:

<img width="1047" height="316" alt="SCR-20260223-hzvx" src="https://github.com/user-attachments/assets/2f637545-30b6-43cf-ba5e-8d240a9ffe1e" />
<img width="505" height="257" alt="SCR-20260223-hyxi" src="https://github.com/user-attachments/assets/ec24699b-092f-46f5-b4f2-ae875c8ab47e" />
